### PR TITLE
Fix for simpleCart.trigger('error')

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -502,7 +502,7 @@
 						msg = message.message;
 					}
 					try { console.log("simpleCart(js) Error: " + msg); } catch (e) {}
-					simpleCart.trigger('error', message);
+					simpleCart.trigger('error', [message]);
 				}
 			});
 


### PR DESCRIPTION
Argument 2 (options) should be an array.

SimpleCart 3.0.5 with "Uncaught TypeError: Function.prototype.apply: Arguments list has wrong type "
http://jsfiddle.net/5QJEd/

Fixed version.
http://jsfiddle.net/JAFAu/
