### PR TITLE
number type support

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -1787,7 +1787,7 @@
 												case "textarea":
 												case "select":
 													type = $item.attr("type");
-													if (!type || ((type.toLowerCase() === "checkbox" || type.toLowerCase() === "radio") && $item.attr("checked")) || type.toLowerCase() === "text") {
+													if (!type || ((type.toLowerCase() === "checkbox" || type.toLowerCase() === "radio") && $item.attr("checked")) || type.toLowerCase() === "text" || type.toLowerCase() === "number") {
 														val = $item.val();
 													}				
 													break;


### PR DESCRIPTION
this way the qty input can be number type. without adding the support it adds only 1 item regardless the value of the input
