### PR TITLE
Don't use the Google Checkout API for Amazon Payments.

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -1076,7 +1076,7 @@
 							, tax_rate:				simpleCart.taxRate()
 							, weight_unit:			opts.weight_unit || 'lb'
 						},
-						action = (opts.sandbox ? "https://sandbox.google.com/checkout/" : "https://checkout.google.com/") + "cws/v2/Merchant/" + opts.merchant_id + "/checkoutForm",
+						action = "https://payments" + (opts.sandbox ? "-sandbox" : "") + ".amazon.com/checkout/" + opts.merchant_id,
 						method = opts.method === "GET" ? "GET" : "POST";
 
 


### PR DESCRIPTION
Fix for issue #343, in which checkouts using Amazon Payments are sent to the Google Checkout API and fail with the error message "Malformed URL component: expected id".
