### PR TITLE
Add element classes to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Here are the possible options and their default values:
 		// "div" or "table" - builds the cart as a table or collection of divs
 		cartStyle: "div", 
 		
+		// CSS classes for generated cart elements
+		cartClass: "", 
+		headerRowClass: "headerRow", 
+		
 		// how simpleCart should checkout, see the checkout reference for more info 
 		checkout: { 
 			type: "PayPal" , 

--- a/simpleCart.js
+++ b/simpleCart.js
@@ -92,6 +92,8 @@
 					language				: "english-us",
 
 					cartStyle				: "div",
+					cartClass				: "",
+					headerRowClass			: "headerRow",
 					cartColumns			: [
 						{ attr: "name", label: "Name" },
 						{ attr: "price", label: "Price", view: 'currency' },
@@ -626,7 +628,7 @@
 						TH = isTable ? 'th' : 'div',
 						TD = isTable ? 'td' : 'div',
 						cart_container = simpleCart.$create(TABLE).addClass(settings.cartClass),
-						header_container = simpleCart.$create(TR).addClass('headerRow'),
+						header_container = simpleCart.$create(TR).addClass(settings.headerRowClass),
 						container = simpleCart.$(selector),
 						column,
 						klass,

--- a/simpleCart.js
+++ b/simpleCart.js
@@ -625,7 +625,7 @@
 						TR = isTable ? "tr" : "div",
 						TH = isTable ? 'th' : 'div',
 						TD = isTable ? 'td' : 'div',
-						cart_container = simpleCart.$create(TABLE),
+						cart_container = simpleCart.$create(TABLE).addClass(settings.cartClass),
 						header_container = simpleCart.$create(TR).addClass('headerRow'),
 						container = simpleCart.$(selector),
 						column,


### PR DESCRIPTION
Adding a class to the wrapper div (or table) for the cart is impossible, as it gets regenerated on every cart update. This lets you set classes for the wrapper element in the cart settings.

Also adds customisation for the header row class, which was previously hard coded.
