### PR TITLE
Fixed incompatibility with MooTools? 1.4.5 (no compatibility layer)

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -1477,6 +1477,9 @@
 						return this;
 					},
 					create: function (selector) {
+						if ( ( window.typeOf || $type )( selector ) === 'array' ) {
+							selector = Array.flatten( selector );
+						}
 						this.el = $engine(selector);
 					}
 


### PR DESCRIPTION
Fixed simpleCart.create - flatten selector argument if type is array. Fix #389

https://github.com/wojodesign/simplecart-js/issues/389
