### PR TITLE
Updated formatting for Japanese yen

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -72,7 +72,7 @@
 					"HKD": { code: "HKD", symbol: "&#36;", name: "Hong Kong Dollar" },
 					"HUF": { code: "HUF", symbol: "&#70;&#116;", name: "Hungarian Forint" },
 					"ILS": { code: "ILS", symbol: "&#8362;", name: "Israeli New Sheqel" },
-					"JPY": { code: "JPY", symbol: "&yen;", name: "Japanese Yen" },
+					"JPY": { code: "JPY", symbol: "&yen;", name: "Japanese Yen", accuracy: 0 },
 					"MXN": { code: "MXN", symbol: "&#36;", name: "Mexican Peso" },
 					"NOK": { code: "NOK", symbol: "NOK&nbsp;", name: "Norwegian Krone" },
 					"NZD": { code: "NZD", symbol: "&#36;", name: "New Zealand Dollar" },


### PR DESCRIPTION
Japanese yen uses no decimal amounts. Id est, this: ¥100 and not this: ¥100.00
