### PR TITLE
remove unnecessary replace in get item price that breaks prices for dot ...

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -862,7 +862,7 @@
 				},
 				price: function (val) {
 					return isUndefined(val) ?
-							parseFloat((this.get("price",true).toString()).replace(simpleCart.currency().symbol,"").replace(simpleCart.currency().delimiter,"") || 1) :
+							parseFloat((this.get("price",true).toString()) || 1) :
 							this.set("price", parseFloat((val).toString().replace(simpleCart.currency().symbol,"").replace(simpleCart.currency().delimiter,"")));
 				},
 				id: function () {


### PR DESCRIPTION
...as delimiter

Price is already cleaned form everything that is not a number or a dot.
So this was unnecessary and - more important - it breaks the price if your delimiter is a dot like in Germany. 

So my nice formated decimals (like 1.75) have been destroyed into integers (175) and become unreal prices...
