### PR TITLE
add custom class support for cart container

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -636,6 +636,9 @@
 						x,
 						xlen;
 
+					// setClass for cart_container
+                                        if(settings.cartClass) cart_container.attr("class", settings.cartClass);
+                                        
 					container.html(' ').append(cart_container);
 
 					cart_container.append(thead_container);


### PR DESCRIPTION
Sometime we want to add class for cart container.
eg:
    I use bootstrap, so I want the table has class 'table'.

simpleCart({
    cartStyle: "table"
    cartClass: 'table'
 })
