### PR TITLE
add option for customDiscount option

### DIFF
--- a/simpleCart.js
+++ b/simpleCart.js
@@ -108,6 +108,7 @@
 					shippingQuantityRate	: 0,
 					shippingTotalRate		: 0,
 					shippingCustom		: null,
+					discountCustom		: null,
 
 					taxRate				: 0,
 					
@@ -367,6 +368,9 @@
 					simpleCart.each(function (item) {
 						total += item.total();
 					});
+                                        /* apply discount */
+                                        var discount = simpleCart.discount();
+                                        total = total * ( 1 - discount/100 );
 					return total;
 				},
 
@@ -553,7 +557,23 @@
 						cost += parseFloat(item.get('shipping') || 0);
 					});
 					return parseFloat(cost);
-				}
+				},
+
+                                discount: function (opt_custom_function) {
+                                    // possibility to define discount with custom function, 
+                                    // it should return discount in %
+                                        if (isFunction(opt_custom_function)) {
+                                                simpleCart({
+                                                        discountCustom: opt_custom_function
+                                                });
+                                                return;
+                                        }
+                                        var discount = 0;
+                                        if (isFunction(settings.discountCustom)) {
+                                                discount = settings.discountCustom.call(simpleCart);
+                                        }
+                                        return discount;
+                                },
 
 			});
 


### PR DESCRIPTION
This hack allows the user to define a customDiscount function which
returns a discount as a number from 0-100 (i.e. a percentage). If the
function is not defined it defaults to 0. The discount is applied to the
total before shipping. (I would like also that the class
.simpleCart_discount could be used in html, but didn't succeed in doing
that.) I think that this is a simple and flexible way to implement
discounts, which seems to be a common requirement.

Something would really need to be added in the docs for this as well. Here is an example customDiscount function:

/\* offer a 20% discount on quantities greater than 5 */
simpleCart.discount(function(){
    var cq = simpleCart.quantity();
    var discount = 0;
    if ( cq > 5) {
      discount = 20;
    }
    return discount;
  });
