### PR TITLE
Fix file inclusion vulnerability

### DIFF
--- a/test/inc/get-raw-javascript.php
+++ b/test/inc/get-raw-javascript.php
@@ -3,7 +3,10 @@
 header('Content-Type: application/javascript');
 
 $url = $_GET['file'];
-
+$urlParts = parse_url($url);
+if ($urlParts['scheme'] === "file") {
+    exit;
+}
 $ch = curl_init($url);
 curl_exec($ch);
 curl_close($ch);


### PR DESCRIPTION
This file curl allows you to view any file on the system. For example, cloning this repository to the base PHP directory makes a vulnerable page look like this

http://example.com/simplecart-js/test/inc/get-raw-javascript.php?file=file:/etc/passwd
